### PR TITLE
A couple of bits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ykmir"
+name = "ykpack"
 version = "0.1.0"
 authors = ["Edd Barrett <vext01@gmail.com>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Edd Barrett <vext01@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 fallible-iterator = "0.1"
 
 # We are using a git version to work around a bug:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,7 @@
 ///
 ///  The version field is automatically written and checked by the `Encoder` and `Decoder`
 ///  respectively.
-
-#[macro_use]
-extern crate serde_derive;
+use serde::{Deserialize, Serialize};
 
 mod decode;
 mod encode;


### PR DESCRIPTION
The first commit was a change missed in the renaming. Found when trying to integrate this with ykrustc.

The second is just a tidy up that we can do thanks to Rust 2018.