### PR TITLE
Fold FalseEdges and FalseUnwind into Goto + discussion.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -105,12 +105,6 @@ pub enum Terminator {
         drop_bb: Option<BasicBlockIndex>,
     },
     GeneratorDrop,
-    FalseEdges {
-        real_target_bb: BasicBlockIndex,
-    },
-    FalseUnwind {
-        real_target_bb: BasicBlockIndex,
-    },
 }
 
 /// The top-level pack type.


### PR DESCRIPTION
As discussed on MM, there's probably no advantage to having `FalseEdges` and `FalseUnwind` distinct from `Goto`.

I've raised this as a draft because there are some other discussion points:

1) In MIR there are a handful of terminators which are effectively "go here or fail" or "go here or do cleanup". Here are some examples:

```
    /// Drop the Place                                                          
    Drop {                                                                      
        location: Place<'tcx>,                                                  
        target: BasicBlock,                                                     
        unwind: Option<BasicBlock>,                                             
    },                                     
...
    /// Jump to the target if the condition has the expected value,             
    /// otherwise panic with a message and a cleanup target.                    
    Assert {                                                                    
        cond: Operand<'tcx>,                                                    
        expected: bool,                                                         
        msg: AssertMessage<'tcx>,                                               
        target: BasicBlock,                                                     
        cleanup: Option<BasicBlock>,                                            
    },             
...                        
    /// A suspend point                                                         
    Yield {                                                                     
        /// The value to return                                                 
        value: Operand<'tcx>,                                                   
        /// Where to resume to                                                  
        resume: BasicBlock,                                                     
        /// Cleanup to be done if the generator is dropped at this suspend point
        drop: Option<BasicBlock>,                                               
    },
```

We might choose to merge these into a regular "if then else" style branch.

2) Also the "SwitchInt" terminator is effectively a N-ary jump table. Do we want this to be our "canonical" branching statement? It might be tempting to break a (e.g.) 3-way jump into two binary decisions, but this would cause the block structure to diverge from that of the MIR (which I think we don't want, right?)...

3) We've said that "bytecode" might not be a good term for our IR. So what should we go for? "TIR" -- Tracing IR? "YIR" Yorick IR? I must admit, I'm not keen on "instruction format". If we can agree on something, I'll udate the terminology in my private branch.

Thoughts?